### PR TITLE
Fix Incorrect Host Name Usage in URI Construction

### DIFF
--- a/lib/rozetka_pay_params.dart
+++ b/lib/rozetka_pay_params.dart
@@ -43,6 +43,9 @@ class RozetkaPayParams {
 
 class RozetkaPayApiParams {
   final String key;
+  /// - Specify the host if you want to use a different one than the default;
+  /// - Host should not include the protocol (http/https);
+  /// - default is "widget.rozetkapay.com".
   final String? host;
 
   RozetkaPayApiParams({required this.key, this.host});

--- a/lib/src/api/api_base.dart
+++ b/lib/src/api/api_base.dart
@@ -9,7 +9,7 @@ import '../utils/log.dart';
 import 'api_sign_utils.dart';
 
 class ApiBase {
-  static const _defaultHost = "https://widget.rozetkapay.com";
+  static const _defaultHost = "widget.rozetkapay.com";
 
   final RozetkaPayApiParams params;
 


### PR DESCRIPTION
### Description:

This PR addresses an issue found in the repository where the default hostname value caused a malformed URI. The original code used:

var uri = Uri.https(_host, path);

with _host defined as "https://widget.rozetkapay.com". Including the protocol (https://) in the _host field is incorrect, as Uri.https already prepends the protocol. This resulted in a URI with a duplicated protocol.

### Changes:

Removed https:// from the _host field, updating it to "widget.rozetkapay.com".
Added a comment above the host definition to clarify that it should contain only the hostname, without the protocol, for proper usage with Uri.https.

### Testing:

Verified that the URI is now correctly constructed as https://widget.rozetkapay.com/<path>.
Please review and let me know if any adjustments are needed!